### PR TITLE
Replace probe endpoint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       # Runs the Super-Linter action
       - name: Run Super-Linter on new changes
         uses: github/super-linter@v6

--- a/nagios_plugins_egi_notebooks/status.py
+++ b/nagios_plugins_egi_notebooks/status.py
@@ -19,15 +19,13 @@ def status2code(status):
 def get_notebook_status(status_url, timeout=10):
     logging.debug('Querying %s for status', status_url)
     try:
-        r = requests.get(status_url, timeout=timeout,
-                         headers={'accept': 'application/json'})
+        r = requests.get(status_url, timeout=timeout)
         r.raise_for_status()
-        status = r.json()
-        logging.debug('Full status message: %s' % status)
-        logging.info("%s: %s", status['code'], status['msg'])
-        return status2code(status['code'])
+        logging.debug('Full message: %s' % r.text)
+        logging.info("%s: %s", r.reason, r.status_code)
+        return status2code(r.reason)
     except (ConnectionError, HTTPError) as e:
-        logging.info("CRITICAL: Unable to get status, %s", e.message)
+        logging.info("CRITICAL: Unable to get status, %s", e)
         return status2code('CRITICAL')
 
 
@@ -44,7 +42,7 @@ def main():
 
     parser.add_argument('--url', help='URL of the the EGI notebooks endpoint')
 
-    parser.add_argument('--status-path', default='services/status/',
+    parser.add_argument('--status-path', default='hub/metrics',
                         help=('Path in the endpoint for the monitoring '
                               'service'))
 
@@ -71,7 +69,5 @@ def main():
     else:
         status_url = opts.url
 
-    if not status_url.endswith('/'):
-        status_url = status_url + '/'
     full_status_url = urljoin(status_url, opts.status_path)
     sys.exit(get_notebook_status(full_status_url, opts.timeout))

--- a/nagios_plugins_egi_notebooks/status.py
+++ b/nagios_plugins_egi_notebooks/status.py
@@ -7,52 +7,58 @@ from six.moves.urllib.parse import urljoin
 import requests
 from requests.exceptions import ConnectionError, HTTPError
 
+
 def status2code(status):
     code_map = {
-        'OK': 0,
-        'WARNING': 1,
-        'CRITICAL': 2,
+        "OK": 0,
+        "WARNING": 1,
+        "CRITICAL": 2,
     }
     return code_map.get(status.upper(), 2)
 
 
 def get_notebook_status(status_url, timeout=10):
-    logging.debug('Querying %s for status', status_url)
+    logging.debug("Querying %s for status", status_url)
     try:
         r = requests.get(status_url, timeout=timeout)
         r.raise_for_status()
-        logging.debug('Full message: %s' % r.text)
+        logging.debug("Full message: %s" % r.text)
         logging.info("%s: %s", r.reason, r.status_code)
         return status2code(r.reason)
     except (ConnectionError, HTTPError) as e:
         logging.info("CRITICAL: Unable to get status, %s", e)
-        return status2code('CRITICAL')
+        return status2code("CRITICAL")
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Nagios plugin for EGI Notebooks',
+        description="Nagios plugin for EGI Notebooks",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        fromfile_prefix_chars='@',
+        fromfile_prefix_chars="@",
         conflict_handler="resolve",
     )
 
-    parser.add_argument('-t', '--timeout', default=10, type=int,
-                        help='Timeout in seconds of the probe')
+    parser.add_argument(
+        "-t", "--timeout", default=10, type=int, help="Timeout in seconds of the probe"
+    )
 
-    parser.add_argument('--url', help='URL of the the EGI notebooks endpoint')
+    parser.add_argument("--url", help="URL of the the EGI notebooks endpoint")
 
-    parser.add_argument('--status-path', default='hub/metrics',
-                        help=('Path in the endpoint for the monitoring '
-                              'service'))
+    parser.add_argument(
+        "--status-path",
+        default="hub/metrics",
+        help=("Path in the endpoint for the monitoring " "service"),
+    )
 
-    parser.add_argument('-v', '--verbose', default=False, action='store_true',
-                        help='Be verbose')
+    parser.add_argument(
+        "-v", "--verbose", default=False, action="store_true", help="Be verbose"
+    )
 
-    parser.add_argument('-H', '--host', help='Host to be checked')
+    parser.add_argument("-H", "--host", help="Host to be checked")
 
-    parser.add_argument('-p', '--port', default=443, type=int,
-                        help='Port to be checked')
+    parser.add_argument(
+        "-p", "--port", default=443, type=int, help="Port to be checked"
+    )
 
     opts = parser.parse_args()
     log_level = logging.INFO
@@ -63,9 +69,9 @@ def main():
     # URL takes precedence over -H and -p
     if not opts.url:
         if not opts.host:
-            logging.error('Mising url or host to check')
-            sys.exit(status2code('CRITICAL'))
-        status_url = 'https://%s:%d/' % (opts.host, opts.port)
+            logging.error("Mising url or host to check")
+            sys.exit(status2code("CRITICAL"))
+        status_url = "https://%s:%d/" % (opts.host, opts.port)
     else:
         status_url = opts.url
 

--- a/nagios_plugins_egi_notebooks/status.py
+++ b/nagios_plugins_egi_notebooks/status.py
@@ -7,7 +7,6 @@ from requests.exceptions import ConnectionError, HTTPError
 from six.moves.urllib.parse import urljoin
 
 
-
 def status2code(status):
     code_map = {
         "OK": 0,

--- a/nagios_plugins_egi_notebooks/status.py
+++ b/nagios_plugins_egi_notebooks/status.py
@@ -2,10 +2,10 @@ import argparse
 import logging
 import sys
 
-from six.moves.urllib.parse import urljoin
-
 import requests
 from requests.exceptions import ConnectionError, HTTPError
+from six.moves.urllib.parse import urljoin
+
 
 
 def status2code(status):


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

I would like to replace the current check to `https://<url>/services/status/` with `https://<url>/hub/metrics`

See: https://jupyterhub.readthedocs.io/en/3.1.1/reference/monitoring.html

It has been tested with:
```bash
egi-notebooks-probe --host jupyterhub.d4science.org
egi-notebooks-probe --host notebooks.egi.eu
egi-notebooks-probe --host replay.notebooks.egi.eu
```

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
